### PR TITLE
Get networking and sutagent up at startup

### DIFF
--- a/full_panda.mk
+++ b/full_panda.mk
@@ -32,6 +32,9 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES := \
         net.dns1=8.8.8.8 \
         net.dns2=8.8.4.4
+PRODUCT_COPY_FILES := \
+        device/ti/panda/network.sh:system/bin/network.sh \
+        device/ti/panda/sut.sh:system/bin/sut.sh
 
 # Inherit from those products. Most specific first.
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base.mk)

--- a/init.omap4pandaboard.rc
+++ b/init.omap4pandaboard.rc
@@ -92,3 +92,9 @@ service dhcpcd_eth0 /system/bin/dhcpcd -ABKL
 service iprenew_eth0 /system/bin/dhcpcd -n
     disabled
     oneshot
+
+service network /system/bin/network.sh
+    class main
+
+service sut /system/bin/sut.sh
+    class main

--- a/network.sh
+++ b/network.sh
@@ -1,0 +1,25 @@
+#!/system/bin/sh
+#set up eth0 networking
+echo insut >> /data/local/netcf.log
+let lim=9
+ifconfig eth0
+if [[ $? != 0 ]] ; then
+  while [[ $lim -gt 0 ]] ; do
+    echo $lim >> /data/local/netcf.log
+    ( netcfg eth0 dhcp ) & sleep 10
+    if [[ $? == 0 ]] ; then
+      echo ran >> /data/local/netcf.log
+      break
+    fi
+    kill $!
+    let lim=lim-1
+  done
+fi
+psoutput=`ps sut`
+echo $psoutput >> /data/local/netcf.log
+if [[ $psoutput != *"sutagent"* ]] ; then
+  echo startingsut >> /data/local/netcf.log
+  export NSPR_LOG_MODULES="NegatusLOG:5, timestamp" && LD_LIBRARY_PATH="/data/local:/data/local/agent:/system/b2g:$LD_LIBRARY_PATH"
+  sutagent &
+  echo started >> /data/local/netcf.log
+fi

--- a/sut.sh
+++ b/sut.sh
@@ -1,0 +1,10 @@
+#!/system/bin/sh
+#set up eth0 networking
+psoutput=`ps sut`
+echo $psoutput >> /data/local/netcf.log
+if [[ $psoutput != *"sutagent"* ]] ; then
+  echo startingsut >> /data/local/netcf.log
+  export NSPR_LOG_MODULES="NegatusLOG:5, timestamp" && LD_LIBRARY_PATH="/data/local:/data/local/agent:/system/b2g:$LD_LIBRARY_PATH"
+  sutagent &>> /data/local/sut.log
+  echo started >> /data/local/netcf.log
+fi


### PR DESCRIPTION
This code turns on ethernet networking and sets up the sutagent at pandaboard startup. This will be used in automation.

The networking script has a few tries in it because I found netcfg to hang at times when I use it on the pandaboard.
