### PR TITLE
Bug 810045: change dhcp client for eth0

### DIFF
--- a/init.omap4pandaboard.rc
+++ b/init.omap4pandaboard.rc
@@ -91,14 +91,10 @@ service iprenew_wlan0 /system/bin/dhcpcd -n
     oneshot
 
 service dhcpcd_eth0 /system/bin/dhcpcd eth0
-    main class
+    class main
     oneshot
 
 service iprenew_eth0 /system/bin/dhcpcd -n
-    disabled
-    oneshot
-
-service netcfg_eth0 /system/bin/netcfg eth0 dhcp
     disabled
     oneshot
 

--- a/init.omap4pandaboard.rc
+++ b/init.omap4pandaboard.rc
@@ -90,8 +90,8 @@ service iprenew_wlan0 /system/bin/dhcpcd -n
     disabled
     oneshot
 
-service dhcpcd_eth0 /system/bin/dhcpcd -ABKL
-    disabled
+service dhcpcd_eth0 /system/bin/dhcpcd eth0
+    main class
     oneshot
 
 service iprenew_eth0 /system/bin/dhcpcd -n
@@ -99,7 +99,7 @@ service iprenew_eth0 /system/bin/dhcpcd -n
     oneshot
 
 service netcfg_eth0 /system/bin/netcfg eth0 dhcp
-    class main
+    disabled
     oneshot
 
 service sut /system/bin/sut.sh
@@ -107,6 +107,6 @@ service sut /system/bin/sut.sh
     disabled
 
 # run sut when network has been configured
-on property:init.svc.netcfg_eth0=stopped
+on property:init.svc.dhcpcd_eth0=stopped
     stop sut
     start sut


### PR DESCRIPTION
When 'netcfg' is called to initialize and obtain an IP from dhcp it fails
on vlans with heavy dhcp traffic.  This patch changes init to call
dhcpcd instead since it handles timeouts and invalid replies better.
This also changes sut to start after dhcpcd forks and exits.
