### PR TITLE
Bug 818506: Enable home button on Linaro-based PandaBoards

### DIFF
--- a/init.omap4pandaboard.rc
+++ b/init.omap4pandaboard.rc
@@ -18,6 +18,8 @@ on post-fs-data
 on boot
 	mount debugfs /sys/kernel/debug /sys/kernel/debug
 	chmod 0666 /dev/pvrsrvkm
+	# enable home button on PandaBoard ES with Linaro
+	write /sys/kernel/debug/omap_mux/abe_mcbsp2_fsx 0x011b
 
 service mklinks /sbin/mklinks
 	disabled
@@ -37,7 +39,6 @@ on fs
 	chown bluetooth bluetooth /sys/class/rfkill/rfkill0/state
 	chmod 0600 /dev/ttyO1
 	chown bluetooth bluetooth /dev/ttyO1
-
 
 # take a wakelock on boot until PM is working
 	write /sys/power/wake_lock hack


### PR DESCRIPTION
When using the Linaro setup for the PandaBoard, the home button doesn't
work out-of-the-box. This patch fixes the button during startup, by setting
the correct flags.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
