### PR TITLE
Associated pull request wrt bug 819563

### DIFF
--- a/720p_touchscreen.idc
+++ b/720p_touchscreen.idc
@@ -1,0 +1,1 @@
+touch.deviceType = touchScreen

--- a/full_panda.mk
+++ b/full_panda.mk
@@ -33,8 +33,8 @@ PRODUCT_PROPERTY_OVERRIDES := \
         net.dns1=8.8.8.8 \
         net.dns2=8.8.4.4
 PRODUCT_COPY_FILES := \
-        device/ti/panda/sut.sh:system/bin/sut.sh
-
+        device/ti/panda/sut.sh:system/bin/sut.sh \
+        device/ti/panda/720p_touchscreen.idc:system/usr/idc/720p_touchscreen.idc
 # Inherit from those products. Most specific first.
 $(call inherit-product, $(SRC_TARGET_DIR)/product/full_base.mk)
 $(call inherit-product, device/ti/panda/device.mk)


### PR DESCRIPTION
This is needed for the gonk input subsystem to correctly recognize the
virtual "device" as a touchscreen.
